### PR TITLE
gettext.w.o: Add World Conquest to campaign textdomains

### DIFF
--- a/gettext.wesnoth.org/includes/config.php
+++ b/gettext.wesnoth.org/includes/config.php
@@ -73,6 +73,7 @@ $mainline_campaign_textdomains = [
 	'wesnoth-trow',
 	'wesnoth-tsg',
 	'wesnoth-utbs',
+	'wesnoth-wc',
 ];
 
 // Additional mainline textdomains


### PR DESCRIPTION
See wesnoth/wesnoth#5100.